### PR TITLE
Make RoundDatetime faster

### DIFF
--- a/src/psykoda/cli/internal.py
+++ b/src/psykoda/cli/internal.py
@@ -756,7 +756,12 @@ def load_log(
     """
 
     from psykoda.io.reader._fujitsu_splunk import FujitsuSplunk
-    from psykoda.preprocess import RoundDatetime, drop_null, set_index
+    from psykoda.preprocess import (
+        FastRoundDatetime,
+        RoundDatetime,
+        drop_null,
+        set_index,
+    )
     from psykoda.utils import daterange2list
 
     daterange = daterange2list(date_from, date_to)
@@ -770,7 +775,7 @@ def load_log(
 
     io = FujitsuSplunk(dir_IDS_log=dir_IDS_log, nrows_read=nrows_read)
     log = set_index(
-        RoundDatetime("hour")(pd.concat(_load_log_catch(io.load_log, daterange)))
+        FastRoundDatetime("hour")(pd.concat(_load_log_catch(io.load_log, daterange)))
     )
     log = drop_null(log)
     return log

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -368,3 +368,43 @@ def test_RoundDateTime():
 
     actual = preprocess.RoundDatetime("hour")(origin_df)
     assert actual.equals(expected)
+
+
+def test_FastRoundDateTime():
+    origin_df = pd.DataFrame(
+        [
+            [datetime.datetime(2020, 1, 1, 1, 2, 3), 0],
+            [datetime.datetime(2020, 1, 1, 4, 5, 6), 1],
+            [datetime.datetime(2021, 2, 3, 4, 0, 0), 2],
+            [datetime.datetime(2021, 3, 4, 0, 0, 0), 3],
+        ],
+        columns=["datetime_full", "dummy"],
+    )
+    expected = pd.DataFrame(
+        [
+            [
+                datetime.datetime(2020, 1, 1, 1, 2, 3),
+                0,
+                datetime.datetime(2020, 1, 1, 1, 0, 0),
+            ],
+            [
+                datetime.datetime(2020, 1, 1, 4, 5, 6),
+                1,
+                datetime.datetime(2020, 1, 1, 4, 0, 0),
+            ],
+            [
+                datetime.datetime(2021, 2, 3, 4, 0, 0),
+                2,
+                datetime.datetime(2021, 2, 3, 4, 0, 0),
+            ],
+            [
+                datetime.datetime(2021, 3, 4, 0, 0, 0),
+                3,
+                datetime.datetime(2021, 3, 4, 0, 0, 0),
+            ],
+        ],
+        columns=["datetime_full", "dummy", "datetime_rounded"],
+    )
+
+    actual = preprocess.FastRoundDatetime("hour")(origin_df)
+    assert actual.equals(expected)


### PR DESCRIPTION
- Speed up RoundDatetime by using numpy universal functions.
- The new class does not support `time_unit`=`month`,`year`. So I didn't delete the old class.